### PR TITLE
Closes 201 on ember-flexberry-data, adds methods for tests on callAction from odata adapter.

### DIFF
--- a/EmberFlexberry/ODataBackend/App_Start/ODataConfig.cs
+++ b/EmberFlexberry/ODataBackend/App_Start/ODataConfig.cs
@@ -73,6 +73,11 @@
             token.Functions.Register(new Func<QueryParameters,IEnumerable<Sotrudnik>>(GetMastersForTest));
             token.Functions.RegisterAction(new Func<QueryParameters, string, string, object>(DeleteAllSelect));
 
+            token.Functions.RegisterAction(new Func<IEnumerable<ApplicationUser>>(ODataTestTypedResult));
+            token.Functions.RegisterAction(new Func<IEnumerable<DataObject>>(ODataTestNotTypedResult));
+            token.Functions.RegisterAction(new Func<IEnumerable<DataObject>>(ODataTestMultyTypedResult));
+            token.Functions.RegisterAction(new Func<IEnumerable<DataObject>>(ODataTestMultyTypedWithLinksResult));
+
             // Event handlers
             token.Events.CallbackAfterCreate = CallbackAfterCreate;
         }
@@ -191,6 +196,42 @@
                     message = msg
                 };
             }
+        }
+
+        private static IEnumerable<ApplicationUser> ODataTestTypedResult()
+        {
+            return new ApplicationUser[]
+            {
+                new ApplicationUser() { Name = "TestName1", EMail = "TestEmail1" },
+                new ApplicationUser() { Name = "TestName2", EMail = "TestEmail2" },
+                new ApplicationUser() { Name = "TestName3", EMail = "TestEmail3" }
+            };
+        }
+
+        private static IEnumerable<DataObject> ODataTestNotTypedResult()
+        {
+            return ODataTestTypedResult();
+        }
+
+        private static IEnumerable<DataObject> ODataTestMultyTypedResult()
+        {
+            return new DataObject[]
+            {
+                new ApplicationUser() { Name = "TestUserName", EMail = "TestUserEmail" },
+                new Suggestion() { Address = "TestSuggestionAddress", Text = "TestSuggestionText" },
+                new SuggestionType() { Name = "TestSuggestionTypeName" }
+            };
+        }
+
+        private static IEnumerable<DataObject> ODataTestMultyTypedWithLinksResult()
+        {
+            var applicationUser = new ApplicationUser() { Name = "TestLinkedUser" };
+
+            return new DataObject[]
+            {
+                new ApplicationUser() { Name = "TestUserName", EMail = "TestUserEmail" },
+                new Suggestion() { Address = "TestSuggestionAddress", Text = "TestSuggestionText", Author = applicationUser }
+            };
         }
     }
 }

--- a/EmberFlexberry/ODataBackend/App_Start/ODataConfig.cs
+++ b/EmberFlexberry/ODataBackend/App_Start/ODataConfig.cs
@@ -198,6 +198,10 @@
             }
         }
 
+        /// <summary>
+        /// OData action for returning one-typed array with known type.
+        /// </summary>
+        /// <returns>One-typed array with known type.</returns>
         private static IEnumerable<ApplicationUser> ODataTestTypedResult()
         {
             return new ApplicationUser[]
@@ -208,11 +212,19 @@
             };
         }
 
+        /// <summary>
+        /// OData action for returning one-typed array with unknown type.
+        /// </summary>
+        /// <returns>One-typed array with unknown type.</returns>
         private static IEnumerable<DataObject> ODataTestNotTypedResult()
         {
             return ODataTestTypedResult();
         }
 
+        /// <summary>
+        /// OData action for returning multy-typed array.
+        /// </summary>
+        /// <returns>Multy-typed array.</returns>
         private static IEnumerable<DataObject> ODataTestMultyTypedResult()
         {
             return new DataObject[]
@@ -223,6 +235,11 @@
             };
         }
 
+        /// <summary>
+        /// OData action for returning multy-typed array with masters.
+        /// But there is a problem with returning masters from odata actions.
+        /// </summary>
+        /// <returns>Multy-typed array with masters.</returns>
         private static IEnumerable<DataObject> ODataTestMultyTypedWithLinksResult()
         {
             var applicationUser = new ApplicationUser() { Name = "TestLinkedUser" };


### PR DESCRIPTION
Added 4 methods in order to test callAction from odata adapter if it can process not typed result.