### PR TITLE
Added example of void action to test its call from ember stand

### DIFF
--- a/EmberFlexberry/ODataBackend/EmberFlexberry.ODataBackend.csproj
+++ b/EmberFlexberry/ODataBackend/EmberFlexberry.ODataBackend.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.11.3" />
     <PackageReference Include="NewPlatform.Flexberry.Reports.ExportToExcel" Version="2.1.0-beta02" />
     <PackageReference Include="NewPlatform.Flexberry.StyleCopRuleset" Version="1.0.0"></PackageReference>
-    <PackageReference Include="NewPlatform.Flexberry.ORM.ODataService" Version="6.1.0"></PackageReference>
+    <PackageReference Include="NewPlatform.Flexberry.ORM.ODataService" Version="6.2.0-beta14"></PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0"></PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LogService.Objects" Version="4.0.0"></PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="6.0.0"></PackageReference>

--- a/EmberFlexberry/ODataBackend/Startup.cs
+++ b/EmberFlexberry/ODataBackend/Startup.cs
@@ -123,6 +123,13 @@
                 token.Functions.RegisterAction(new Func<IEnumerable<DataObject>>(ODataTestMultyTypedResult));
                 token.Functions.RegisterAction(new Func<IEnumerable<DataObject>>(ODataTestMultyTypedWithLinksResult));
 
+                // Register void action.
+                token.Functions.Register(new NewPlatform.Flexberry.ORM.ODataService.Functions.Action(
+                                    "ExecuteVoidAction",
+                                    ExecuteVoidAction,
+                                    typeof(void),
+                                    new Dictionary<string, Type>()));
+
                 // Event handlers
                 token.Events.CallbackAfterCreate = CallbackAfterCreate;
                 token.Events.CallbackBeforeUpdate = CallBackBeforeUpdate;
@@ -192,6 +199,15 @@
             container.RegisterSingleton<ISecurityManager, EmptySecurityManager>();
             container.RegisterSingleton<IDataService, PostgresDataService>(
                 Inject.Property(nameof(PostgresDataService.CustomizationString), connStr));
+        }
+
+        /// <summary>
+        /// Method to check how void action returns 204 NoContent.
+        /// </summary>
+        /// <param name="queryParameters">Some parameters.</param>
+        private static void ExecuteVoidAction(QueryParameters queryParameters, IDictionary<string, object> parameters)
+        {
+            System.Diagnostics.Debug.WriteLine("Void method was executed.");
         }
 
         private static IEnumerable<Sotrudnik> GetMastersForTest(QueryParameters queryParameters)


### PR DESCRIPTION
В пакете ODataService добавлена возможность регистрировать Action без возвращаемого результата.
Данный ПР необходим для выполнения тестирования, как эмбер-стенд будет вызывать таким образом зарегистрированный Action.